### PR TITLE
Fix trying to get property of non-object.

### DIFF
--- a/dkan_harvest.migrate.inc
+++ b/dkan_harvest.migrate.inc
@@ -59,7 +59,7 @@ class DataJSONList extends MigrateList {
   public function getIdList() {
     $ids = array();
     $cache = cache_get('dkan_harvest_ids');
-    if ($cache->data && count($cache->data) == count($this->files)) {
+    if ($cache && isset($cache->data) && count($cache->data) == count($this->files)) {
       return array_keys($cache->data);
     }
     else {


### PR DESCRIPTION
When cache_get returns False we cannot try to load data from it.

Ref NuCivic/healthdata#361

The error I was getting was:

``````
File /var/www/healthdata/docroot/sites/all/modules/contrib/dkan_harvest/dkan_harvest.migrate.inc, line 62(file:
/var/www/healthdata/docroot/sites/all/modules/contrib/dkan_harvest/dkan_harvest.migrate.inc, line 62)```
``````
