### PR TITLE
Use microtime(TRUE) for time updated.

### DIFF
--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -51,7 +51,7 @@ function dkan_harvest_migrate_data() {
  * Callback for dkan-cache-harvested-data.
  */
 function dkan_harvest_cache_data() {
-  $harvest_last_updated = microtime();
+  $harvest_last_updated = microtime(TRUE);
   $sources = dkan_harvest_sources_definition();
   dkan_harvest_cache_data_process($sources, $harvest_last_updated);
 }

--- a/test/DKANHarvestBaseTest.php
+++ b/test/DKANHarvestBaseTest.php
@@ -83,7 +83,7 @@ class DKANHarvestBaseTest extends PHPUnit_Framework_TestCase
     {
       $this->assertEquals(file_exists("public://dkan-harvest-cache/demo.getdkan.com/90a2b708-7fea-4b92-8aee-43c4cfdd5f48"), NULL);
       $sources = $this->DKANTestSource();
-      dkan_harvest_cache_data_process($sources, microtime());
+      dkan_harvest_cache_data_process($sources, microtime(TRUE));
       $this->assertFileExists("public://dkan-harvest-cache/demo.getdkan.com/90a2b708-7fea-4b92-8aee-43c4cfdd5f48");
       $this->assertFileExists("public://dkan-harvest-cache/demo.getdkan.com/c2150dce-db96-4007-ba3f-fb4f3774902d");
     }


### PR DESCRIPTION
The migration module does not use microtime() but microtime(TRUE) to set times.
If we only use microtime() we may run into issues where the updates do not
happen as expected.

```
$ drush eval "echo microtime()";
================================
0.14977500 1439906669

$ drush eval "echo microtime(TRUE);"
====================================
1439906717.5205

$ grep microtime -rn /var/www/healthdata/docroot/sites/all/modules/contrib/migrate;
==================================================================================

/var/www/healthdata/docroot/sites/all/modules/contrib/migrate/includes/base.inc:907:    $this->starttime = microtime(TRUE);
/var/www/healthdata/docroot/sites/all/modules/contrib/migrate/includes/base.inc:934:                       'starttime' => round(microtime(TRUE) * 1000),
/var/www/healthdata/docroot/sites/all/modules/contrib/migrate/includes/base.inc:979:              'endtime' => round(microtime(TRUE) * 1000),
/var/www/healthdata/docroot/sites/all/modules/contrib/migrate/includes/base.inc:1086:          $time = microtime(TRUE) - $this->starttime;
/var/www/healthdata/docroot/sites/all/modules/contrib/migrate/includes/migration.inc:1081:    $time = microtime(TRUE) - $this->lastfeedback;

``
```
