### PR TITLE
Re-add modified column to migration table.

### DIFF
--- a/dkan_harvest.install
+++ b/dkan_harvest.install
@@ -17,6 +17,16 @@ function dkan_harvest_disable() {
 }
 
 /**
+ * Implements hook_enable().
+ */
+function dkan_harvest_enable() {
+  Migration::registerMigration('dkan_harvest_data_json');
+
+  $table = _dkan_migrate_base_data_json_table('dkan_harvest_data_json');
+  dkan_migrate_base_add_modified_column($table);
+}
+
+/**
  * Changes length of uuid field to support URLs.
  */
 function dkan_harvest_update_7001(&$sandbox) {


### PR DESCRIPTION
Ref: https://github.com/NuCivic/healthdata/issues/518

After this module gets disabled the migration table will get dropped and so will
the modified column. This commit re register the migration table and adds the
modified column back to the table.

This PR depends on https://github.com/NuCivic/dkan_migrate_base/pull/28.
- [x] Disable and then re-enable module.  The following modified column should be present.

```
mysql> describe migrate_map_dkan_harvest_data_json;
+-----------------+---------------------+------+-----+---------+-------+
| Field           | Type                | Null | Key | Default | Extra |
+-----------------+---------------------+------+-----+---------+-------+
| sourceid1       | varchar(255)        | NO   | PRI | NULL    |       |
| destid1         | int(10) unsigned    | YES  |     | NULL    |       |
| needs_update    | tinyint(3) unsigned | NO   |     | 0       |       |
| rollback_action | tinyint(3) unsigned | NO   |     | 0       |       |
| last_imported   | int(10) unsigned    | NO   |     | 0       |       |
| hash            | varchar(32)         | YES  |     | NULL    |       |
| modified        | varchar(32)         | NO   |     |         |       |
+-----------------+---------------------+------+-----+---------+-------+
7 rows in set (0.00 sec)

```
