### PR TITLE
Add sources option to drush dkan-chd.

### DIFF
--- a/dkan_harvest.drush.inc
+++ b/dkan_harvest.drush.inc
@@ -13,7 +13,10 @@ function dkan_harvest_drush_command() {
   $items['dkan-cache-harvested-data'] = array(
     'aliases' => array('dkan-chd'),
     'description' => 'Caches remote data.json endpoints locally',
-    'callback' => 'dkan_harvest_cache_data',
+    'callback' => 'dkan_harvest_drush_chd',
+    'options' => array(
+      'sources' => 'A list of comma delimited source keys as provided in hook_harvest_sources.',
+    ),
   );
   // Runs the migration.
   $items['dkan-migrate-cached-data'] = array(
@@ -28,4 +31,15 @@ function dkan_harvest_drush_command() {
     'callback' => 'dkan_harvest_run',
   );
   return $items;
+}
+
+
+/**
+ * Callback function for dkan-chd command.
+ */
+function dkan_harvest_drush_chd() {
+  $options = array();
+  $options['sources'] = drush_get_option('sources', FALSE);
+  $options['sources'] = $options['sources'] ? explode(',', $options['sources']) : array();
+  return dkan_harvest_cache_data($options);
 }

--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -50,10 +50,13 @@ function dkan_harvest_migrate_data() {
 /**
  * Callback for dkan-cache-harvested-data.
  */
-function dkan_harvest_cache_data() {
+function dkan_harvest_cache_data($options = array()) {
   $harvest_last_updated = microtime();
   $sources = dkan_harvest_sources_definition();
-  dkan_harvest_cache_data_process($sources, $harvest_last_updated);
+  if (!empty($options)) {
+    $sources = array_intersect_key($sources, array_flip($options['sources']));
+  }
+  return dkan_harvest_cache_data_process($sources, $harvest_last_updated);
 }
 
 /**
@@ -104,7 +107,7 @@ function dkan_harvest_cache_data_process($sources, $harvest_last_updated) {
     $n += $counter;
   }
   $message = $n . ' datasets harvested in total';
-  dkan_harvest_log($message, 'success');
+  return dkan_harvest_log($message, 'success');
 }
 
 /**
@@ -117,6 +120,7 @@ function dkan_harvest_log($message, $type) {
   else {
     watchdog('dkan_harvest', $message);
   }
+  return $message;
 }
 
 /**

--- a/test/DKANHarvestBaseTest.php
+++ b/test/DKANHarvestBaseTest.php
@@ -89,6 +89,19 @@ class DKANHarvestBaseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers dkan_harvest_cache_data().
+     */
+    public function testDKANHarvestCacheData()
+    {
+      $options = array(
+        'sources' => array('www.google.com'),
+      );
+      $expected = "0 datasets harvested in total";
+      $actual = dkan_harvest_cache_data($options);
+      $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * @covers dkan_harvest_filter_datasets().
      */
     public function testDKANHarvestDatasetFilter()


### PR DESCRIPTION
As a developer I sometimes want to focus a harvest to one single source in order to help debug.

Ref nucivic/healthdata#609.
- [ ] `drush dkan-chd --sources=www.google.com` works (returns 0 datasets)
- [ ] Unit tests pass.
