### PR TITLE
NCS-58: Fix dataset caching problem caused by characters encoding

### DIFF
--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -90,6 +90,7 @@ function dkan_harvest_cache_data_process($sources, $harvest_last_updated) {
           break;
 
         case 'data.json':
+          $remote = utf8_encode($remote);
           $json = drupal_json_decode($remote);
           if ($json) {
             dkan_harvest_cache_pod_1_1_json($json, $key, $source, $counters);

--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -92,6 +92,11 @@ function dkan_harvest_cache_data_process($sources, $harvest_last_updated) {
         case 'data.json':
           $remote = utf8_encode($remote);
           $json = drupal_json_decode($remote);
+          if (!$json) {
+            # Anticipate encoding errors.
+            $remote = utf8_encode($remote);
+            $json = drupal_json_decode($remote);
+          }
           if ($json) {
             dkan_harvest_cache_pod_1_1_json($json, $key, $source, $counters);
           }


### PR DESCRIPTION
- Fix dataset caching problem caused by characters encoding in data.json sources.

ref https://jira.govdelivery.com/browse/NCS-58
