### PR TITLE
Remove 'groups were updated...' messages when harvesting datasets

### DIFF
--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -280,7 +280,7 @@ function dkan_harvest_harvest_now_form_submit($form, &$form_state) {
 function dkan_harvest_message_cleanup() {
   $orig_messages = drupal_get_messages('status') + array('status' => array());
   foreach ($orig_messages['status'] as $message) {
-    if(!preg_match('/\bgroups\b/i', $message)) {
+    if(!preg_match('/\bgroups were updated\b/i', $message)) {
       drupal_set_message($message, 'status');
     }
   }

--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -270,7 +270,20 @@ function dkan_harvest_harvest_now_form_submit($form, &$form_state) {
   $harvestSource = HarvestSource::getHarvestSourceFromNode($form['#node']);
   dkan_harvest_cache_sources(array($harvestSource));
   dkan_harvest_migrate_sources(array($harvestSource));
+  dkan_harvest_message_cleanup();
   $form_state['redirect'] = 'admin/dkan/harvest/dashboard';
+}
+
+/**
+ * Do not display 'Groups were updated on X resources' messages when harvesting datasets.
+*/
+function dkan_harvest_message_cleanup() {
+  $orig_messages = drupal_get_messages('status') + array('status' => array());
+  foreach ($orig_messages['status'] as $message) {
+    if(!preg_match('/\bgroups\b/i', $message)) {
+      drupal_set_message($message, 'status');
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## issue

civic-3886
## ac

Add a harvest source, confirm there are no messages about groups being udated

![dkan_harvest_dashboard___dkan_and__civic-3891__delete_dataset_option_on_dashboard_-_jira](https://cloud.githubusercontent.com/assets/314172/18071334/a6639f68-6e1a-11e6-8fc0-f30143ff4689.png)
