### PR TITLE
Fix node-view dataset count function

### DIFF
--- a/dkan_harvest.module
+++ b/dkan_harvest.module
@@ -135,8 +135,8 @@ function dkan_harvest_render_field_multiple($field) {
  */
 function dkan_harvest_datasets_count($source) {
   $source = HarvestSource::getHarvestSourceFromNode($source);
-  $cached = $source->cache();
-  return count($cached->processed);
+  $count = HarvestSource::getMigrationCountFromMachineName($source->machine_name);
+  return $count;
 }
 
 /**


### PR DESCRIPTION
Fix the dataset count on the source node sidebar.
## AC
1. Add a source using http://demo.getdkan.com
2. Enter a filter: keyword/workforce
3. Harvest
4. Confirm the sidebar block shows a count of 1

![dkan](https://cloud.githubusercontent.com/assets/314172/18142372/e37a6d82-6f82-11e6-925e-765a5bdf7558.png)
